### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/default-golang-ci.yml
+++ b/.github/workflows/default-golang-ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/default-golang-setup.yml
+++ b/.github/workflows/default-golang-setup.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         name: 🔧 Set up Node.js

--- a/.github/workflows/default-node-npm-ci.yml
+++ b/.github/workflows/default-node-npm-ci.yml
@@ -57,7 +57,7 @@ on:
 jobs:
   verify:
     name: 🔎 Lint and Test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
       new-release-version: ${{ steps.get-next-version.outputs.new-release-version }}

--- a/.github/workflows/default-node-pnpm-ci.yml
+++ b/.github/workflows/default-node-pnpm-ci.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   verify:
     name: 🔎 Lint and Test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
       new-release-version: ${{ steps.get-next-version.outputs.new-release-version }}

--- a/.github/workflows/node-pnpm-setup.yml
+++ b/.github/workflows/node-pnpm-setup.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Use Node.js ${{ inputs.node-version }}


### PR DESCRIPTION
Replace compatible GitHub-hosted runner selections with the self-hosted runner.